### PR TITLE
Fix: Correct asset paths for GitHub Pages deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     
     <!-- Add your favicon links here -->
     
-    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
 
@@ -41,7 +41,7 @@
             </section>
 
             <section class="cv-download">
-                 <a href="/assets/Thapelo_Masebe_CV.pdf" class="download-button" download>Download Full CV (PDF)</a>
+                 <a href="assets/Thapelo_Masebe_CV.pdf" class="download-button" download>Download Full CV (PDF)</a>
             </section>
         </aside>
 
@@ -85,6 +85,6 @@
 
     </main>
 
-    <script type="module" src="/js/main.js"></script>
+    <script type="module" src="js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The existing asset paths in `index.html` were absolute (e.g., `/css/style.css`), which prevented them from loading correctly on GitHub Pages, as the site is served from a subdirectory.

This commit updates the paths for the CSS, JavaScript, and CV PDF to be relative, allowing them to resolve correctly and enabling the site to render as intended when deployed.