### PR TITLE
Add Google Tag Manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,24 @@
     <title>Thapelo Madiba Masebe | Transdisciplinary Practitioner</title>
     <meta name="description" content="The digital CV and professional hub for Thapelo Madiba Masebe, a transdisciplinary artist, creative technologist, and emerging data scientist.">
     
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5S2BNKVS');</script>
+    <!-- End Google Tag Manager -->
+
     <!-- Add your favicon links here -->
      <favicon href="/assets/favicon.ico">
     
     <link rel="stylesheet" href="./css/style.css">
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5S2BNKVS"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
 
     <main class="cv-container">
         


### PR DESCRIPTION
This commit adds the Google Tag Manager script to the website for analytics and tracking.

- The main GTM script has been added to the `<head>` section of `index.html`.
- The corresponding `<noscript>` tag has been added to the `<body>` section as a fallback.
